### PR TITLE
Fix various issues with specs

### DIFF
--- a/lib/pbcs.ex
+++ b/lib/pbcs.ex
@@ -15,7 +15,8 @@ defmodule PBCS do
   @type protected :: %{alg: String.t(), enc: String.t(), p2c: pos_integer, p2s: binary}
   @type opts :: Keyword.t()
 
-  @spec encrypt({tag, plain_text}, protected, opts) :: cipher_text
+  @spec encrypt({tag(), plain_text()}, protected(), opts()) ::
+          cipher_text() | {:error, String.t()}
   def encrypt({tag, plain_text}, protected, opts) do
     case KeyManager.encrypt(protected, opts) do
       {:ok, protected, key, encrypted_key, content_encryptor} ->
@@ -41,7 +42,7 @@ defmodule PBCS do
     end
   end
 
-  @spec decrypt({tag, cipher_text}, opts) :: plain_text
+  @spec decrypt({tag(), cipher_text()}, opts()) :: plain_text() | {:error, String.t()} | :error
   def decrypt({tag, cipher_text}, opts) do
     {:ok, cipher_text} = Utils.base64url_decode(cipher_text)
 

--- a/lib/pbcs/aes_cbc_hmac_sha2.ex
+++ b/lib/pbcs/aes_cbc_hmac_sha2.ex
@@ -9,8 +9,8 @@ defmodule PBCS.AES_CBC_HMAC_SHA2 do
   See: https://tools.ietf.org/html/rfc7518#section-5.2.6
   """
 
-  @spec content_encrypt({binary, binary}, <<_::32>> | <<_::48>> | <<_::64>>, <<_::16>>) ::
-          {binary, <<_::16>> | <<_::24>> | <<_::32>>}
+  @spec content_encrypt({binary, PBCS.plain_text()}, binary(), binary()) ::
+          {PBCS.cipher_text(), binary()}
   def content_encrypt({aad, plain_text}, key, iv)
       when is_binary(aad) and is_binary(plain_text) and bit_size(key) in [256, 384, 512] and
              bit_size(iv) === 128 do
@@ -25,11 +25,8 @@ defmodule PBCS.AES_CBC_HMAC_SHA2 do
     {cipher_text, cipher_tag}
   end
 
-  @spec content_decrypt(
-          {binary, binary, <<_::16>> | <<_::24>> | <<_::32>>},
-          <<_::32>> | <<_::48>> | <<_::64>>,
-          <<_::16>>
-        ) :: {:ok, binary} | :error
+  @spec content_decrypt({binary(), PBCS.cipher_text(), PBCS.tag()}, binary(), binary()) ::
+          {:ok, PBCS.plain_text()} | :error
   def content_decrypt({aad, cipher_text, cipher_tag}, key, iv)
       when is_binary(aad) and is_binary(cipher_text) and bit_size(cipher_tag) in [128, 192, 256] and
              bit_size(key) in [256, 384, 512] and bit_size(iv) === 128 do

--- a/lib/pbcs/aes_gcm.ex
+++ b/lib/pbcs/aes_gcm.ex
@@ -10,16 +10,16 @@ defmodule PBCS.AES_GCM do
 
   @behaviour ContentEncryptor
 
-  @spec content_encrypt({binary, binary}, <<_::16>> | <<_::24>> | <<_::32>>, <<_::12>>) ::
-          {binary, <<_::16>>}
+  @spec content_encrypt({binary, PBCS.plain_text()}, binary(), binary()) ::
+          {PBCS.cipher_text(), binary()}
   def content_encrypt({aad, plain_text}, key, iv)
       when is_binary(aad) and is_binary(plain_text) and bit_size(key) in [128, 192, 256] and
              bit_size(iv) === 96 do
     :crypto.block_encrypt(:aes_gcm, key, iv, {aad, plain_text})
   end
 
-  @spec content_decrypt({binary, binary, <<_::16>>}, <<_::16>> | <<_::24>> | <<_::32>>, <<_::12>>) ::
-          {:ok, binary} | :error
+  @spec content_decrypt({binary(), PBCS.cipher_text(), PBCS.tag()}, binary(), binary()) ::
+          {:ok, PBCS.plain_text()} | :error
   def content_decrypt({aad, cipher_text, cipher_tag}, key, iv)
       when is_binary(aad) and is_binary(cipher_text) and bit_size(cipher_tag) === 128 and
              bit_size(key) in [128, 192, 256] and bit_size(iv) === 96 do

--- a/lib/pbcs/content_encryptor.ex
+++ b/lib/pbcs/content_encryptor.ex
@@ -55,10 +55,18 @@ defmodule PBCS.ContentEncryptor do
     end
   end
 
+  @spec encrypt(PBCS.ContentEncryptor.t(), binary(), binary(), {binary(), PBCS.plain_text()}) ::
+          {binary(), PBCS.cipher_text()}
   def encrypt(%ContentEncryptor{module: module, params: params}, key, iv, {aad, plain_text}) do
     module.encrypt(params, key, iv, {aad, plain_text})
   end
 
+  @spec decrypt(
+          PBCS.ContentEncryptor.t(),
+          binary(),
+          binary(),
+          {binary(), PBCS.cipher_text(), binary()}
+        ) :: {:ok, PBCS.plain_text()} | :error
   def decrypt(
         %ContentEncryptor{module: module, params: params},
         key,
@@ -68,14 +76,17 @@ defmodule PBCS.ContentEncryptor do
     module.decrypt(params, key, iv, {aad, cipher_text, cipher_tag})
   end
 
+  @spec generate_key(PBCS.ContentEncryptor.t()) :: binary()
   def generate_key(%ContentEncryptor{module: module, params: params}) do
     module.generate_key(params)
   end
 
+  @spec generate_iv(PBCS.ContentEncryptor.t()) :: binary()
   def generate_iv(%ContentEncryptor{module: module, params: params}) do
     module.generate_iv(params)
   end
 
+  @spec key_length(PBCS.ContentEncryptor.t()) :: pos_integer()
   def key_length(%ContentEncryptor{module: module, params: params}) do
     module.key_length(params)
   end


### PR DESCRIPTION
1. Add possible error returns to PBCS.encrypt and PBCS.decrypt
2. Fix warnings on content_encrypt/content_decrypt functions
3. Use more specific types in a few places
4. Spread more parentheses around for consistency