### PR TITLE
Add missing :crypto dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule PBCS.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:crypto]
     ]
   end
 


### PR DESCRIPTION
This fixes the following Elixir 1.11 warning:

```
warning: :crypto.block_decrypt/4 defined in application :crypto is used
by the current application but the current application does not directly
depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under
:extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps"
in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may
optionally skip this warning by adding [xref: [exclude: :crypto]] to
your "def project" in mix.exs

Found at 3 locations:
  lib/pbcs/aes_cbc_hmac_sha2.ex:94:
PBCS.AES_CBC_HMAC_SHA2.aes_cbc_decrypt/3
  lib/pbcs/aes_cbc_hmac_sha2.ex:100:
PBCS.AES_CBC_HMAC_SHA2.aes_cbc_decrypt/3
  lib/pbcs/aes_gcm.ex:26: PBCS.AES_GCM.content_decrypt/3
```

It also removes `:logger` since neither the Elixir or Erlang loggers are
used by this project.